### PR TITLE
Use callbacks to implement async return

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,18 +27,31 @@ license that can be found in the LICENSE file.
 			mod = result.module;
 			inst = result.instance;
 			document.getElementById("runButton").disabled = false;
+			run();
 		});
 
 		async function run() {
-			console.clear();
 			await go.run(inst);
+			
 			inst = await WebAssembly.instantiate(mod, go.importObject); // reset instance
 		}
+
+
+		function output(str) {
+			document.querySelector('#output').innerHTML = str;
+		}
+
+		function convert() {
+			let input = document.querySelector('#input').value;
+			blackfridayFormat(input, output);
+		}
+
+
 	</script>
 
 	<textarea id="input" placeholder="Enter your markdown"></textarea>
 	<div id="output"></div>
-	<button onClick="run();" id="runButton" disabled>Convert</button>
+	<button onClick="convert();" id="runButton" disabled>Convert</button>
 </body>
 
 </html>

--- a/lib.go
+++ b/lib.go
@@ -2,20 +2,19 @@ package main
 
 import (
 	"syscall/js"
+
 	"gopkg.in/russross/blackfriday.v2"
 )
 
 func main() {
-	inputArea := js.Global().Get("document").Call("getElementById", "input")
-	inputText := inputArea.Get("value").String()
-	result := format(inputText)
-
-	outputDiv := js.Global().Get("document").Call("getElementById", "output")
-	outputDiv.Set("innerHTML", result)
+	c := make(chan struct{}, 0)
+	js.Global().Set("blackfridayFormat", js.NewCallback(format))
+	<-c
 }
 
-func format(input string) string {
-	outputBytes := blackfriday.Run([]byte(input))
+func format(input []js.Value) {
+	message := input[0].String()
+	outputBytes := blackfriday.Run([]byte(message))
 	output := string(outputBytes)
-	return output
+	input[1].Invoke(output)
 }


### PR DESCRIPTION
There is as solution to "return" things from wasm but as you said in the video because everything is async the only way to do it is to use a callback as a second parameter. This PR exposes the function `blackfridayFormat(input, cb)` where `input` is a string and `cb` is a function that takes the resulting string as the first parameter. 

